### PR TITLE
[HOTFIX] refactor s3 config to support aws v4

### DIFF
--- a/02.static-web-site-in-s3/provider.tf
+++ b/02.static-web-site-in-s3/provider.tf
@@ -1,6 +1,7 @@
 # Configure the AWS Provider
 provider "aws" {
   region = "eu-west-3" # Paris
+  # version = "~> 3.0" # Uncomment this if you'd like to use an old version instead of refactoring the s3 config
   # profile    = "your-aws-user-account"
 
   # access_key = "$var.access_key"

--- a/02.static-web-site-in-s3/s3-bucket.tf
+++ b/02.static-web-site-in-s3/s3-bucket.tf
@@ -5,8 +5,8 @@ resource "aws_s3_bucket" "b" {
   provisioner "local-exec" {
     command = "aws s3 sync ./www/ s3://${aws_s3_bucket.b.id} --delete --acl public-read"
   }
-
 }
+
 resource "aws_s3_bucket_acl" "b" {
   bucket = aws_s3_bucket.b.id
   acl    = "public-read"

--- a/02.static-web-site-in-s3/s3-bucket.tf
+++ b/02.static-web-site-in-s3/s3-bucket.tf
@@ -1,17 +1,29 @@
 resource "aws_s3_bucket" "b" {
   bucket        = var.bucket_name
-  acl           = "public-read"
   force_destroy = true
 
-  website {
-    index_document = "index.html"
-    error_document = "error.html"
+  provisioner "local-exec" {
+    command = "aws s3 sync ./www/ s3://${aws_s3_bucket.b.id} --delete --acl public-read"
+  }
+
+}
+resource "aws_s3_bucket_acl" "b" {
+  bucket = aws_s3_bucket.b.id
+  acl    = "public-read"
+}
+
+resource "aws_s3_bucket_website_configuration" "b" {
+  bucket = aws_s3_bucket.b.id
+  
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
   }
 
   provisioner "local-exec" {
-    command = "echo Uploading website to ${aws_s3_bucket.b.website_endpoint}"
-  }
-  provisioner "local-exec" {
-    command = "aws s3 sync ./www/ s3://${aws_s3_bucket.b.id} --delete --acl public-read"
+    command = "echo Uploading website to ${aws_s3_bucket_website_configuration.b.website_endpoint}"
   }
 }


### PR DESCRIPTION
This PR fixes some issues with the current terraform s3 config, due to the new `AWS Provider Version 4.0.0`. This was done with the help of the following guide: [Terraform AWS Provider Version 4 Upgrade Guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#website-website_domain-and-website_endpoint-arguments)


![graphviz](https://user-images.githubusercontent.com/26777462/156588472-1dd1bfff-da09-432c-88cd-88943be2d8bf.png)

